### PR TITLE
Revert "Feature varying groupsizes"

### DIFF
--- a/GFA_Renamer.ahk
+++ b/GFA_Renamer.ahk
@@ -190,43 +190,15 @@ GFARSubmit() {
     script.config.LastRun.Folder:=Folder
     script.config.LastRun.Names:=Names
     script.config.LastRun.PlantsPerGroup:=PlantsPerGroup
-    if (InStr(PlantsPerGroup,",")) { ;; we have designated group sizes
-        totalNumber:=0
-        Counts:=strsplit(PlantsPerGroup,",")
-        GroupNames:=strsplit(Names,",")
-        if (Counts.Count() != GroupNames.Count()) {
-            Gui +OwnDialogs
-            MsgBox 0x40010,% script.name " - Critical error: Parameters incompatible",% "You provided a list of varying number of pots/plants per group: `n" PlantsPerGroup "`n for " Counts.Count() " groups`, but also provided names for " GroupNames.Count() " groups:`n" Names "`n`nPlease fix this error by aligning both."
-            return
-        }
-        for each, Name in Groupnames {
-            loop, % Counts[each] {
-                Arr.push(Name " (" A_Index ")")
-            }
-        }
-        LoopCount:=PlantsPerGroup*strsplit(Names,",").Count()
-        loop % LoopCount
-        {
-            bReset:=(!(mod(A_Index,PlantsPerGroup))) ;; force a reset in call_index every 'PlantsPerGroup'
-            GroupName:=repeatElementIofarrayNKtimes(strsplit(Names,","),PlantsPerGroup,,bReset,Names)
-            Number:=repeatIndex(PlantsPerGroup)
-            Arr.push(GroupName " (" Number ")")
-            if (bReset) {
+    LoopCount:=PlantsPerGroup*strsplit(Names,",").Count()
+    loop % LoopCount
+    {
+        bReset:=(!(mod(A_Index,PlantsPerGroup))) ;; force a reset in call_index every 'PlantsPerGroup'
+        GroupName:=repeatElementIofarrayNKtimes(strsplit(Names,","),PlantsPerGroup,,bReset,Names)
+        Number:=repeatIndex(PlantsPerGroup)
+        Arr.push(GroupName " (" Number ")")
+        if (bReset) {
 
-            }
-        }
-    } else {
-
-        LoopCount:=PlantsPerGroup*strsplit(Names,",").Count()
-        loop % LoopCount
-        {
-            bReset:=(!(mod(A_Index,PlantsPerGroup))) ;; force a reset in call_index every 'PlantsPerGroup'
-            GroupName:=repeatElementIofarrayNKtimes(strsplit(Names,","),PlantsPerGroup,,bReset,Names)
-            Number:=repeatIndex(PlantsPerGroup)
-            Arr.push(GroupName " (" Number ")")
-            if (bReset) {
-
-            }
         }
     }
     ;ttip(repeatElementIofarrayNKtimes())
@@ -255,10 +227,7 @@ GFARSubmit() {
     until you have them all line up again.
     */
     if (ImagePaths.Count() > Arr.Count()) {
-        MsgBox 0x40010, % script.name " - Critical error: More images than names defined"
-            , % "The folder you provided contains " ImagePaths.Count() " images. The combination of the 'number of groups' and 'plants per group' you provided only allows for renaming " Arr.Count() " images."
-            . "`nBe aware that only those first " Arr.Count() " images will be renamed, (and copied to the clipboard)"
-        ImageF:=ImagePaths[Arr.Count()]
+        msgbox % "Critical error: you have more images than names available"
     }
     gui GFAR_Exclude: new, +AlwaysOnTop -SysMenu -ToolWindow -caption +Border +hwndGFAR_ExcludeGui
     gui GFAR_Exclude: +OwnerGFAR
@@ -390,10 +359,6 @@ GFAR_ExcludeSubmit() {
         Log:="Expected Number of images: " TrueNumberOfFiles "`nFound Number of images: " Sel.Count() "`n"
         LogBody:=""
         FilestoCopy:=""
-        if (TEST_FOLDERPATH!="") {
-            Folder:=TEST_FOLDERPATH
-        }
-        FileRecycle % Folder "\assets\Image Test Files\GFAR_WD"
         for Sel_Index,Sel_String in Sel ;; iterate over all entries that we left checked. These will be renamed based on the Entries of the Listview - the name displayed will be applied to the respectively displayed filename
         {
             if (TEST_FOLDERPATH!="") {


### PR DESCRIPTION
Adds ability to rename images belonging to groups of varying group sizes. 

LIMITATION: 

The inputs 
    Group1, Group2, Group3, Group1
    2,3,3,4
    
are still invalid, because this would create two copies of 

    Group1 (1)
    Group1 (2)

once from the first group rename (Group: `Group1`, Size: `2`), and once from the second group rename (Group: `Group1`,Size: `4`).

Thus, images belonging to the same group must still be grouped together and in numerical ascending order from 1 to N.